### PR TITLE
Query API before log Set

### DIFF
--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1983,6 +1983,12 @@ sai_status_t VendorSai::logSet(
 
     m_logLevelMap[api] = log_level;
 
+    void *api_method_table = nullptr;
+    sai_status_t status = m_globalApis.api_query(api, &api_method_table);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        return status;
+    }
     return m_globalApis.log_set(api, log_level);
 }
 


### PR DESCRIPTION
While setting loglevel for SAI_API's , we are receiving out of range error message. This usally happens when there is a SAI headers mismatch between SONiC and Vendor SAI.

To address the error from SAI , Added a sai query before setting the log level. 